### PR TITLE
Remove `RTLTextPlugin` default

### DIFF
--- a/docs/api-reference/map.md
+++ b/docs/api-reference/map.md
@@ -495,6 +495,8 @@ Note that since some map options cannot be modified after initialization, when r
 
 #### `RTLTextPlugin`: object {#rtltextplugin}
 
+Default: `undefined`
+
 - `pluginUrl`: `string` URL to the plugin JS file.
 - `lazy`: `boolean` When true, the plugin is only loaded when the map first encounters Hebrew or Arabic text. Default `true`.
 

--- a/docs/api-reference/map.md
+++ b/docs/api-reference/map.md
@@ -493,14 +493,12 @@ If `reuseMaps` is set to `true`, when a map component is unmounted, the underlyi
 
 Note that since some map options cannot be modified after initialization, when reusing maps, only the reactive props and `initialViewState` of the new component are respected.
 
-#### `RTLTextPlugin`: string | false {#rtltextplugin}
+#### `RTLTextPlugin`: object {#rtltextplugin}
 
-Default: `'https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-rtl-text/v0.2.3/mapbox-gl-rtl-text.js'`
+- `pluginUrl`: `string` URL to the plugin JS file.
+- `lazy`: `boolean` When true, the plugin is only loaded when the map first encounters Hebrew or Arabic text. Default `true`.
 
-Sets the map's [RTL text plugin](https://www.mapbox.com/mapbox-gl-js/plugins/#mapbox-gl-rtl-text). Necessary for supporting the Arabic and Hebrew languages, which are written right-to-left.
-
-Setting this prop is the equivalent of calling [setRTLTextPlugin](https://maplibre.org/maplibre-gl-js/docs/API/functions/setRTLTextPlugin/) with `lazy: true`. Set to `false` to disable loading the RTL text plugin.
-
+Sets the map's RTL text plugin via [setRTLTextPlugin](https://maplibre.org/maplibre-gl-js/docs/API/functions/setRTLTextPlugin/). Can be used with [mapbox-gl-rtl-text](https://github.com/mapbox/mapbox-gl-rtl-text). Necessary for supporting the Arabic and Hebrew languages, which are written right-to-left.
 
 #### `workerCount`: number {#workercount}
 

--- a/docs/upgrade-guide.md
+++ b/docs/upgrade-guide.md
@@ -19,7 +19,7 @@ The following Mapbox-only props from `react-map-gl`'s Map component are removed:
 - `workerClass`
 - `baseApiUrl`
 
-### Removed default for `RTLTextPlugin`
+### Explicitly set `RTLTextPlugin` (if needed)
 
 The default `RTLTextPlugin` loaded from mapbox.com has been removed.
 To keep the previous behavior, specify the `pluginUrl` which was previously used or supply the plugin from any other source:

--- a/docs/upgrade-guide.md
+++ b/docs/upgrade-guide.md
@@ -2,6 +2,8 @@
 
 ## Migrating from react-map-gl
 
+### Update Imports
+
 `@vis.gl/react-maplibre` v1.0 can be used as a drop-in replacement of `react-map-gl` v7:
 
 ```patch
@@ -9,7 +11,24 @@
 + import {Map, Marker} from '@vis.gl/react-maplibre';
 ```
 
+### Remove Mapbox-only Props
+
 The following Mapbox-only props from `react-map-gl`'s Map component are removed:
+
 - `mapboxAccessToken`
 - `workerClass`
 - `baseApiUrl`
+
+### Removed default for `RTLTextPlugin`
+
+The default `RTLTextPlugin` loaded from mapbox.com has been removed.
+To keep the previous behavior, specify the `pluginUrl` which was previously used or supply the plugin from any other source:
+
+```tsx
+<Map
+  RTLTextPlugin={{
+    pluginUrl:
+      'https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-rtl-text/v0.2.3/mapbox-gl-rtl-text.js'
+  }}
+/>
+```

--- a/src/utils/set-globals.ts
+++ b/src/utils/set-globals.ts
@@ -4,7 +4,7 @@ export type GlobalSettings = {
    */
   maxParallelImageRequests?: number;
   /** The map's RTL text plugin. Necessary for supporting the Arabic and Hebrew languages, which are written right-to-left.  */
-  RTLTextPlugin?: string | false;
+  RTLTextPlugin?: {pluginUrl: string; lazy?: boolean};
   /** The number of web workers instantiated on a page with maplibre-gl maps.
    * @default 2
    */
@@ -16,26 +16,21 @@ export type GlobalSettings = {
 };
 
 export default function setGlobals(mapLib: any, props: GlobalSettings) {
-  const {
-    RTLTextPlugin = 'https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-rtl-text/v0.2.3/mapbox-gl-rtl-text.js',
-    maxParallelImageRequests,
-    workerCount,
-    workerUrl
-  } = props;
+  const {RTLTextPlugin, maxParallelImageRequests, workerCount, workerUrl} = props;
   if (
     RTLTextPlugin &&
     mapLib.getRTLTextPluginStatus &&
     mapLib.getRTLTextPluginStatus() === 'unavailable'
   ) {
     mapLib.setRTLTextPlugin(
-      RTLTextPlugin,
+      RTLTextPlugin.pluginUrl,
       (error?: Error) => {
         if (error) {
           // eslint-disable-next-line
           console.error(error);
         }
       },
-      true
+      RTLTextPlugin.lazy ?? true
     );
   }
   if (maxParallelImageRequests !== undefined) {


### PR DESCRIPTION
As discussed previously, I've removed the default value for the `RTLTextPlugin` which loaded from mapbox.com. This aligns more closely to the default behavior of the maplib, forcing the user to manually set such url. The prop now also accepts an object, to allow full configuration of the `setRTLTextPlugin` call.

Fixes https://github.com/visgl/react-maplibre/issues/7

BREAKING CHANGE: RTLTextPlugin must now be set manually as prop